### PR TITLE
Improved Logs functionality

### DIFF
--- a/backend/fitnex_api/exercise/serializers.py
+++ b/backend/fitnex_api/exercise/serializers.py
@@ -51,7 +51,7 @@ class ExerciseLogSerializers(serializers.ModelSerializer):
 
     class Meta:
         model = Exercise
-        fields = ('id', 'name', 'bodyPart_data')
+        fields = ('id', 'name', 'gifUrl', 'bodyPart_data')
 
     def get_bodyPart_data(self, instance):
         return instance.bodyPart.name if instance.bodyPart else None

--- a/backend/fitnex_api/exercise/utils.py
+++ b/backend/fitnex_api/exercise/utils.py
@@ -79,11 +79,12 @@ def download_and_upload_image(gif_url, folder='fitnex_gifs'):
         print('Done')
 
 
-def get_month_name(date_str):
+def get_date_details(date_str):
     try:
         date_obj = datetime.strptime(date_str, '%Y-%m-%d')
-        month_name = date_obj.strftime('%B')
-        return month_name
+        month = date_obj.strftime('%B')
+        year = date_obj.strftime('%Y')
+        return (month, year)
     except ValueError:
         return None
 
@@ -92,8 +93,7 @@ def get_organized_data(logs):
     output = {}
     for log in logs:
         date_str = log.get('date_created')
-        year, _, _ = date_str.split('-')
-        month = get_month_name(date_str)
+        month, year = get_date_details(date_str)
 
         if year not in output:
             output[year] = {}

--- a/backend/fitnex_api/exercise/utils.py
+++ b/backend/fitnex_api/exercise/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from dotenv import load_dotenv
 import cloudinary
 import cloudinary.exceptions
@@ -76,3 +77,27 @@ def download_and_upload_image(gif_url, folder='fitnex_gifs'):
         # except Exception as e:
         #     print(f"Error removing temporary file: {e}")
         print('Done')
+
+
+def get_month_name(date_str):
+    try:
+        date_obj = datetime.strptime(date_str, '%Y-%m-%d')
+        month_name = date_obj.strftime('%B')
+        return month_name
+    except ValueError:
+        return None
+
+
+def get_organized_data(logs):
+    output = {}
+    for log in logs:
+        date_str = log.get('date_created')
+        year, _, _ = date_str.split('-')
+        month = get_month_name(date_str)
+
+        if year not in output:
+            output[year] = {}
+        if month not in output[year]:
+            output[year][month] = []
+        output[year][month].append(log)
+    return output


### PR DESCRIPTION
In this pull request, I added a few extra functionality:

- Made sure that the API prevented the creation of multiple log objects in a day. Only a single log object can be created or exist in a day.
- Included the GIF image URL in the serialized (JSON) data representation for each exercise belonging to a log object 
- Added the ability to filter the logs to be returned based on the month and even the year of creation of said log.
- Refactored some of the code and added comments where I thought they were necessary.